### PR TITLE
Implement Practice Mode

### DIFF
--- a/rabi_splitter_WPF/MainContext.cs
+++ b/rabi_splitter_WPF/MainContext.cs
@@ -6,9 +6,38 @@ using System.Linq;
 using System.Text;
 using System.Windows.Data;
 using rabi_splitter_WPF.Annotations;
+using System.Windows;
 
 namespace rabi_splitter_WPF
 {
+    [ValueConversion(typeof(bool), typeof(Visibility))]
+    public class InvertableBooleanToVisibilityConverter : IValueConverter
+    {
+        #region IValueConverter Members
+        // Code taken from http://stackoverflow.com/a/2427307
+        enum Parameter
+        {
+            VisibleWhenTrue, VisibleWhenFalse
+        }
+
+        public object Convert(object value, Type targetType, object parameter,
+            System.Globalization.CultureInfo culture)
+        {
+            var boolValue = (bool)value;
+            var direction = (Parameter)Enum.Parse(typeof(Parameter), (string)parameter);
+
+            if (direction == Parameter.VisibleWhenTrue) return boolValue ? Visibility.Visible : Visibility.Collapsed;
+            else return boolValue ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter,
+            System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+        #endregion
+    }
+
     [ValueConversion(typeof(bool), typeof(bool))]
     public class InverseBooleanConverter : IValueConverter
     {
@@ -132,6 +161,7 @@ namespace rabi_splitter_WPF
     class MainContext : INotifyPropertyChanged
 
     {
+        private bool _practiceMode;
         private bool _musicStart;
         private bool _musicEnd;
         private bool _computer;
@@ -183,6 +213,17 @@ namespace rabi_splitter_WPF
                     var ts = dt - LastBossEnd.Value;
                     return ts.ToString(@"mm\:ss\.f");
                 }
+            }
+        }
+
+        public bool PracticeMode
+        {
+            get { return _practiceMode; }
+            set
+            {
+                if (value == _practiceMode) return;
+                _practiceMode = value;
+                OnPropertyChanged(nameof(PracticeMode));
             }
         }
 

--- a/rabi_splitter_WPF/MainContext.cs
+++ b/rabi_splitter_WPF/MainContext.cs
@@ -379,7 +379,7 @@ namespace rabi_splitter_WPF
 
         public bool ForceAlius1
         {
-            get => _forceAlius1;
+            get { return _forceAlius1; }
             set
             {
                 if (value == _forceAlius1) return;
@@ -415,6 +415,8 @@ namespace rabi_splitter_WPF
         public int lastmapid;
         public int lastmusicid;
         public int lastplaytime = 0;
+        public bool canReload = false; // set to true when playtime increases
+
         private bool bossbattle;
         public List<int> lastbosslist;
         public int lastnoah3hp;

--- a/rabi_splitter_WPF/MainWindow.xaml
+++ b/rabi_splitter_WPF/MainWindow.xaml
@@ -9,6 +9,7 @@
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <local:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
+        <local:InvertableBooleanToVisibilityConverter x:Key="InvertableBooleanToVisibilityConverter"/>
     </Window.Resources>
     <DockPanel>
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Left">
@@ -32,20 +33,33 @@
                     <TextBlock TextWrapping="Wrap" Text="/" FontSize="16" Margin="10,0"/>
                     <TextBlock TextWrapping="Wrap" Text="{Binding RoutingTimer}" FontSize="16"/>
                 </StackPanel>
-                <CheckBox Content="Split when BOSS music STARTS" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MusicStart, Mode=TwoWay}"/>
-                <CheckBox Content="Split when BOSS music ENDS" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MusicEnd, Mode=TwoWay}"/>
-                <CheckBox Content="Split when the computer is found" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Computer, Mode=TwoWay}"/>
-                <CheckBox Content="Split when Miru despawns" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MiruDe, Mode=TwoWay}"/>
-                <CheckBox Content="Ignore the Side Chapter" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding SideCh, Mode=TwoWay}"/>
-                <CheckBox Content="Force split after Alius I" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding ForceAlius1, Mode=TwoWay}"  />
-                <CheckBox Content="Ignore the &quot;M.R.&quot; (Reload on Noah 1)" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Noah1Reload, Mode=TwoWay}" IsEnabled="{Binding AutoReset, Converter={StaticResource InverseBooleanConverter},Mode=TwoWay}"/>
-                <CheckBox Content="Split when Town Member +2 or Nixie despawns" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Tm2, Mode=TwoWay}"/>
-                <CheckBox Content="Ignore Irisu Phase 1" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Irisu1, Mode=TwoWay}"/>
-                <CheckBox Content="Don't split on reload during boss (1.75, experimental)" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding DontSplitOnReload, Mode=TwoWay}"/>
-                <CheckBox Content="Track In-Game Time" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Igt, Mode=TwoWay}"/>
-                <CheckBox Content="Start timer on game start (1.75 only)" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding AutoStart, Mode=TwoWay}"/>
-                <CheckBox Content="Reset timer when returning to title screen" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding AutoReset, Mode=TwoWay}"/>
-                <CheckBox Content="Show debug area" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding DebugArea, Mode=TwoWay}"/>
+                <CheckBox Content="Practice Mode" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding PracticeMode, Mode=TwoWay}"/>
+                <StackPanel Visibility="{Binding PracticeMode, Converter={StaticResource InvertableBooleanToVisibilityConverter}, ConverterParameter=VisibleWhenTrue, FallbackValue=Collapsed}">
+                    <StackPanel Name="PracticeModePanel" d:DataContext="{d:DesignData local:PracticeModeContext}">
+                        <TextBlock>Start Timer When:</TextBlock>
+                        <ComboBox ItemsSource="{Binding SplitTriggerCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=StartTimerSetting, Mode=TwoWay}"/>
+                        <TextBlock>Split Timer When:</TextBlock>
+                        <ComboBox ItemsSource="{Binding SplitTriggerCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=SplitTimerSetting, Mode=TwoWay}"/>
+                        <TextBlock>Reset Timer When:</TextBlock>
+                        <ComboBox ItemsSource="{Binding SplitTriggerCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=ResetTimerSetting, Mode=TwoWay}"/>
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel Visibility="{Binding PracticeMode, Converter={StaticResource InvertableBooleanToVisibilityConverter}, ConverterParameter=VisibleWhenFalse, FallbackValue=Visible}">
+                    <CheckBox Content="Split when BOSS music STARTS" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MusicStart, Mode=TwoWay}"/>
+                    <CheckBox Content="Split when BOSS music ENDS" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MusicEnd, Mode=TwoWay}"/>
+                    <CheckBox Content="Split when the computer is found" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Computer, Mode=TwoWay}"/>
+                    <CheckBox Content="Split when Miru despawns" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MiruDe, Mode=TwoWay}"/>
+                    <CheckBox Content="Ignore the Side Chapter" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding SideCh, Mode=TwoWay}"/>
+                    <CheckBox Content="Force split after Alius I" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding ForceAlius1, Mode=TwoWay}"  />
+                    <CheckBox Content="Ignore the &quot;M.R.&quot; (Reload on Noah 1)" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Noah1Reload, Mode=TwoWay}" IsEnabled="{Binding AutoReset, Converter={StaticResource InverseBooleanConverter},Mode=TwoWay}"/>
+                    <CheckBox Content="Split when Town Member +2 or Nixie despawns" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Tm2, Mode=TwoWay}"/>
+                    <CheckBox Content="Ignore Irisu Phase 1" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Irisu1, Mode=TwoWay}"/>
+                    <CheckBox Content="Don't split on reload during boss (1.75, experimental)" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding DontSplitOnReload, Mode=TwoWay}"/>
+                    <CheckBox Content="Track In-Game Time" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding Igt, Mode=TwoWay}"/>
+                    <CheckBox Content="Start timer on game start (1.75 only)" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding AutoStart, Mode=TwoWay}"/>
+                    <CheckBox Content="Reset timer when returning to title screen" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding AutoReset, Mode=TwoWay}"/>
+                    <CheckBox Content="Show debug area" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding DebugArea, Mode=TwoWay}"/>
+                </StackPanel>
             </StackPanel>
             <DockPanel Visibility="{Binding DebugArea, Converter={StaticResource BooleanToVisibilityConverter}, Mode=TwoWay}" >
                 <TextBlock TextWrapping="Wrap" Text="debug area" Height="15.24" Width="352.251" DockPanel.Dock="Top"/>

--- a/rabi_splitter_WPF/PracticeModeContext.cs
+++ b/rabi_splitter_WPF/PracticeModeContext.cs
@@ -1,0 +1,118 @@
+﻿using rabi_splitter_WPF.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace rabi_splitter_WPF
+{
+    enum SplitTrigger
+    {
+        None,
+        BossStart,
+        BossEnd,
+        Reload,
+        MapChange,
+        MusicChange,
+    }
+    
+    
+    class PracticeModeContext : INotifyPropertyChanged
+    {
+        private SplitTrigger _startTimerSetting = SplitTrigger.BossStart;
+        private SplitTrigger _splitTimerSetting = SplitTrigger.BossEnd;
+        private SplitTrigger _stopTimerSetting = SplitTrigger.Reload;
+        private static readonly Dictionary<SplitTrigger, string> _splitTriggerCaptions = new Dictionary<SplitTrigger, string>()
+        {
+            {SplitTrigger.None, "None"},
+            {SplitTrigger.BossStart, "Boss Start"},
+            {SplitTrigger.BossEnd, "Boss End"},
+            {SplitTrigger.Reload, "Reload"},
+            {SplitTrigger.MapChange, "Map Change (Experimental)"},
+            {SplitTrigger.MusicChange, "Music Change (Experimental)"},
+        };
+
+        public Dictionary<SplitTrigger, string> SplitTriggerCaptions
+        {
+            get { return _splitTriggerCaptions; }
+        }
+
+        public SplitTrigger StartTimerSetting
+        {
+            get { return _startTimerSetting; }
+            set
+            {
+                if (value == _startTimerSetting) return;
+                _startTimerSetting = value;
+                OnPropertyChanged(nameof(StartTimerSetting));
+            }
+        }
+
+        public SplitTrigger SplitTimerSetting
+        {
+            get { return _splitTimerSetting; }
+            set
+            {
+                if (value == _splitTimerSetting) return;
+                _splitTimerSetting = value;
+                OnPropertyChanged(nameof(SplitTimerSetting));
+            }
+        }
+
+        public SplitTrigger ResetTimerSetting
+        {
+            get { return _stopTimerSetting; }
+            set
+            {
+                if (value == _stopTimerSetting) return;
+                _stopTimerSetting = value;
+                OnPropertyChanged(nameof(ResetTimerSetting));
+            }
+        }
+        
+        private bool _sendStart;
+        private bool _sendSplit;
+        private bool _sendReset;
+
+        public void SendTrigger(SplitTrigger trigger)
+        {
+            if (StartTimerSetting == trigger) _sendStart = true;
+            if (SplitTimerSetting == trigger) _sendSplit = true;
+            if (ResetTimerSetting == trigger) _sendReset = true;
+        }
+
+        public void ResetSendTriggers()
+        {
+            _sendStart = false;
+            _sendSplit= false;
+            _sendReset = false;
+        }
+
+        // Send only one message at a time.
+        // Currently prioritise Reset > Start > Split
+        public bool SendStartTimerThisFrame()
+        {
+            return !_sendReset && _sendStart;
+        }
+
+        public bool SendSplitTimerThisFrame()
+        {
+            return !_sendReset && !_sendStart && _sendSplit;
+        }
+
+        public bool SendResetTimerThisFrame()
+        {
+            return _sendReset;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/rabi_splitter_WPF/rabi_splitter_WPF.csproj
+++ b/rabi_splitter_WPF/rabi_splitter_WPF.csproj
@@ -55,6 +55,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="PracticeModeContext.cs" />
     <Compile Include="StaticData.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Practice Mode is on a separate menu, that shows up when you check the "Practice Mode" checkbox.

You can set the condition to Start/Split/Reset in practice mode.

There's one issue with this though.
So for example if we the Start Condition and the Split Condition are the same (e.g. on music change), we don't know whether we should send a "split" or a "start" message. We can't send both, or LiveSplit will just get confused.
Theoretically, we should send a start if the timer is not running, and a split if the timer is running.  But we can't detect if the livesplit timer is currently running.
What we do now is that, if we prioritise Reset > Start > Split, and send only the one with higher priority. Not a really good solution, but whatever.

But our main use case is:
- Start on boss start
- Split on boss end
- Reset on reload

This main use case works perfectly fine. Thus the other split options, (Music Change, Map Change) are marked as experimental features.
