### PR TITLE
Implement splitting on map tile in practice mode

### DIFF
--- a/rabi_splitter_WPF/MainContext.cs
+++ b/rabi_splitter_WPF/MainContext.cs
@@ -175,6 +175,8 @@ namespace rabi_splitter_WPF
         private int _serverPort;
         private string _gameVer;
         private string _gameMusic;
+        private string _gameMap;
+        private string _gameMapTile;
         private bool _igt;
         public bool _autoReset;
         public bool _autoStart;
@@ -384,6 +386,28 @@ namespace rabi_splitter_WPF
             }
         }
 
+        public string GameMap
+        {
+            get { return _gameMap; }
+            set
+            {
+                if (value == _gameMap) return;
+                _gameMap = value;
+                OnPropertyChanged(nameof(GameMap));
+            }
+        }
+
+        public string GameMapTile
+        {
+            get { return _gameMapTile; }
+            set
+            {
+                if (value == _gameMapTile) return;
+                _gameMapTile = value;
+                OnPropertyChanged(nameof(GameMapTile));
+            }
+        }
+
         public bool Igt
         {
             get { return _igt; }
@@ -456,6 +480,7 @@ namespace rabi_splitter_WPF
         public int lastmapid;
         public int lastmusicid;
         public int lastplaytime = 0;
+        public MainWindow.MapTileCoordinate lastMapTile = MainWindow.MapTileCoordinate.FromWorldPosition(0,0,0);
         public bool canReload = false; // set to true when playtime increases
 
         private bool bossbattle;
@@ -464,7 +489,7 @@ namespace rabi_splitter_WPF
         public int lastTM;
         public DateTime LastTMAddTime;
         private bool _noah1Reload;
-
+        
         public MainContext()
         {
             this.MusicEnd = true;

--- a/rabi_splitter_WPF/MainWindow.xaml
+++ b/rabi_splitter_WPF/MainWindow.xaml
@@ -40,6 +40,20 @@
                         <local:SplitConditionSettings VerticalAlignment="Top" Label="Split Timer When" SplitConditionObject="{Binding SplitTimerSetting}"/>
                         <local:SplitConditionSettings VerticalAlignment="Top" Label="Reset Timer When" SplitConditionObject="{Binding ResetTimerSetting}"/>
                     </StackPanel>
+                    <StackPanel Margin="0,10,0,0">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,0,0,3">
+                            <TextBlock TextWrapping="Wrap" Text="Music: " FontSize="16"/>
+                            <TextBlock TextWrapping="Wrap" Text="{Binding GameMusic}" FontSize="16"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,0,0,3">
+                            <TextBlock TextWrapping="Wrap" Text="Map: " FontSize="16"/>
+                            <TextBlock TextWrapping="Wrap" Text="{Binding GameMap}" FontSize="16"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,0,0,3">
+                            <TextBlock TextWrapping="Wrap" Text="Map Tile: " FontSize="16"/>
+                            <TextBlock TextWrapping="Wrap" Text="{Binding GameMapTile}" FontSize="16"/>
+                        </StackPanel>
+                    </StackPanel>
                 </StackPanel>
                 <StackPanel Visibility="{Binding PracticeMode, Converter={StaticResource InvertableBooleanToVisibilityConverter}, ConverterParameter=VisibleWhenFalse, FallbackValue=Visible}">
                     <CheckBox Content="Split when BOSS music STARTS" HorizontalAlignment="Left" FontSize="15" Margin="0,0,0,4" IsChecked="{Binding MusicStart, Mode=TwoWay}"/>

--- a/rabi_splitter_WPF/MemoryHelper.cs
+++ b/rabi_splitter_WPF/MemoryHelper.cs
@@ -4,21 +4,40 @@ using System.Runtime.InteropServices;
 
 namespace rabi_splitter_WPF
 {
-    public  static  class MemoryHelper
+    public class MemoryHelper : IDisposable
     {
         [DllImport("kernel32.dll")]
         public static extern IntPtr OpenProcess(int dwDesiredAccess, bool bInheritHandle, int dwProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CloseHandle(IntPtr hObject);
 
         [DllImport("kernel32.dll")]
         public static extern bool ReadProcessMemory(int hProcess,
             int lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesRead);
 
-        [DllImport("kernel32", SetLastError = true)]
-        static extern bool CloseHandle(IntPtr handle);
-
         private const int PROCESS_WM_READ = 0x0010;
 
-        public static T GetMemoryValue<T>(Process process, int addr,bool baseaddr=true)
+        private readonly IntPtr processHandle;
+        private readonly int processHandleInt;
+        private readonly int baseAddress;
+
+        public MemoryHelper(Process process)
+        {
+            processHandle = OpenProcess(PROCESS_WM_READ, false, process.Id);
+            processHandleInt = (int)processHandle;
+            baseAddress = process.MainModule.BaseAddress.ToInt32();
+        }
+
+        /*
+        public static T GetMemoryValue<T>(Process process, int addr, bool baseaddr = true)
+        {
+            var memoryHelper = new MemoryHelper(process);
+            return memoryHelper.GetMemoryValue<T>(addr, baseaddr);
+        }
+        */
+
+        public T GetMemoryValue<T>(int addr, bool baseaddr = true)
         {
             int datasize;
             switch (Type.GetTypeCode(typeof(T)))
@@ -30,19 +49,24 @@ namespace rabi_splitter_WPF
                 case TypeCode.SByte:
                     datasize = 1;
                     break;
+
                 case TypeCode.Int16:
                 case TypeCode.UInt16:
                     datasize = 2;
                     break;
-                case TypeCode.Int32:
 
+                case TypeCode.Int32:
+                case TypeCode.Single:
                 case TypeCode.UInt32:
                     datasize = 4;
                     break;
+
+                case TypeCode.Double:
                 case TypeCode.Int64:
                 case TypeCode.UInt64:
                     datasize = 8;
                     break;
+
                 default:
                     throw new Exception("not supported");
             }
@@ -50,46 +74,47 @@ namespace rabi_splitter_WPF
             byte[] buffer = new byte[datasize];
             int bytesRead = 0;
 
-            IntPtr processHandle = OpenProcess(PROCESS_WM_READ, false, process.Id);
             if (baseaddr)
-            { ReadProcessMemory((int) processHandle, process.MainModule.BaseAddress.ToInt32() + addr, buffer,
-                    datasize, ref bytesRead);}
+            {
+                ReadProcessMemory(processHandleInt, baseAddress + addr, buffer, datasize, ref bytesRead);
+            }
             else
             {
-                ReadProcessMemory((int)processHandle, addr, buffer,
-                       datasize, ref bytesRead);
-
+                ReadProcessMemory(processHandleInt, addr, buffer, datasize, ref bytesRead);
             }
-            CloseHandle(processHandle);
+
             switch (Type.GetTypeCode(typeof(T)))
             {
 
                 case TypeCode.Boolean:
-                    return (T)Convert.ChangeType( buffer[0] == 1,typeof(T));
+                    return (T)Convert.ChangeType(buffer[0] == 1, typeof(T));
 
                 case TypeCode.Byte:
                 case TypeCode.SByte:
-                    return (T)Convert.ChangeType(buffer[0] , typeof(T));
+                    return (T)Convert.ChangeType(buffer[0], typeof(T));
                 case TypeCode.Char:
                     return (T)Convert.ChangeType((char)buffer[0], typeof(T));
 
+                case TypeCode.Single:
+                    return (T)Convert.ChangeType(BitConverter.ToSingle(buffer, 0), typeof(T));
 
                 case TypeCode.Int16:
-               
-                    return (T)Convert.ChangeType(BitConverter.ToInt16(buffer,0), typeof(T));
-                   
+                    return (T)Convert.ChangeType(BitConverter.ToInt16(buffer, 0), typeof(T));
                 case TypeCode.UInt16:
                     return (T)Convert.ChangeType(BitConverter.ToUInt16(buffer, 0), typeof(T));
                 case TypeCode.Int32:
                     return (T)Convert.ChangeType(BitConverter.ToInt32(buffer, 0), typeof(T));
                 case TypeCode.UInt32:
                     return (T)Convert.ChangeType(BitConverter.ToUInt32(buffer, 0), typeof(T));
-                   
+
+                case TypeCode.Double:
+                    return (T)Convert.ChangeType(BitConverter.ToDouble(buffer, 0), typeof(T));
+
                 case TypeCode.Int64:
                     return (T)Convert.ChangeType(BitConverter.ToInt64(buffer, 0), typeof(T));
                 case TypeCode.UInt64:
                     return (T)Convert.ChangeType(BitConverter.ToUInt64(buffer, 0), typeof(T));
-                    
+
                 default:
                     throw new Exception("not supported");
             }
@@ -97,5 +122,28 @@ namespace rabi_splitter_WPF
         }
 
 
+        #region IDisposable Support
+        private bool disposed = false;
+
+        protected virtual void DisposeUnmanagedResources()
+        {
+            if (disposed) return;
+
+            CloseHandle(processHandle);
+
+            disposed = true;
+        }
+
+        ~MemoryHelper()
+        {
+            DisposeUnmanagedResources();
+        }
+
+        public void Dispose()
+        {
+            DisposeUnmanagedResources();
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
     }
 }

--- a/rabi_splitter_WPF/PracticeModeContext.cs
+++ b/rabi_splitter_WPF/PracticeModeContext.cs
@@ -6,6 +6,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 
+using MapTileCoordinate = rabi_splitter_WPF.MainWindow.MapTileCoordinate;
+
 namespace rabi_splitter_WPF
 {
     public enum SplitTrigger
@@ -16,6 +18,7 @@ namespace rabi_splitter_WPF
         Reload,
         MapChange,
         MusicChange,
+        MapTileChange,
     }
 
     public enum ParameterOptions
@@ -81,6 +84,12 @@ namespace rabi_splitter_WPF
         private ExtendedOptions<Map> _mapTypeTo;
         private ExtendedOptions<Music> _musicTypeFrom;
         private ExtendedOptions<Music> _musicTypeTo;
+        private bool _mapTileFromAny;
+        private int _mapTileFromX;
+        private int _mapTileFromY;
+        private bool _mapTileToAny;
+        private int _mapTileToX;
+        private int _mapTileToY;
 
         #region Dictionaries 
 
@@ -96,6 +105,7 @@ namespace rabi_splitter_WPF
             {SplitTrigger.Reload, "Reload"},
             {SplitTrigger.MapChange, "Map Change"},
             {SplitTrigger.MusicChange, "Music Change"},
+            {SplitTrigger.MapTileChange, "Map Tile Change"},
         };
 
         // Captions for Split Trigger Parameter Options
@@ -172,6 +182,18 @@ namespace rabi_splitter_WPF
             return new SplitCondition() { TriggerType = SplitTrigger.MusicChange, MusicTypeFrom = oldMusicExtended, MusicTypeTo = newMusicExtended };
         }
 
+        public static SplitCondition MapTileChange(MapTileCoordinate oldMapTile, MapTileCoordinate newMapTile)
+        {
+            return new SplitCondition()
+            {
+                TriggerType = SplitTrigger.MapTileChange,
+                MapTileFromX = oldMapTile.x,
+                MapTileFromY = oldMapTile.y,
+                MapTileToX = newMapTile.x,
+                MapTileToY = newMapTile.y,
+            };
+        }
+
         public bool Matches(SplitCondition condition)
         {
             if (TriggerType != condition.TriggerType) return false;
@@ -184,6 +206,11 @@ namespace rabi_splitter_WPF
             {
                 if (!(MusicTypeFrom.option == ParameterOptions.Any || MusicTypeFrom.Equals(condition.MusicTypeFrom))) return false;
                 if (!(MusicTypeTo.option == ParameterOptions.Any || MusicTypeTo.Equals(condition.MusicTypeTo))) return false;
+            }
+            if (TriggerType == SplitTrigger.MapTileChange)
+            {
+                if (!(MapTileFromAny || (MapTileFromX == condition.MapTileFromX && MapTileFromY == condition.MapTileFromY))) return false;
+                if (!(MapTileToAny || (MapTileToX == condition.MapTileToX && MapTileToY == condition.MapTileToY))) return false;
             }
             return true;
         }
@@ -244,6 +271,72 @@ namespace rabi_splitter_WPF
                 if (value.Equals(_musicTypeTo)) return;
                 _musicTypeTo = value;
                 OnPropertyChanged(nameof(MusicTypeTo));
+            }
+        }
+
+        public bool MapTileFromAny
+        {
+            get { return _mapTileFromAny; }
+            set
+            {
+                if (value.Equals(_mapTileFromAny)) return;
+                _mapTileFromAny = value;
+                OnPropertyChanged(nameof(MapTileFromAny));
+            }
+        }
+
+        public int MapTileFromX
+        {
+            get { return _mapTileFromX; }
+            set
+            {
+                if (value.Equals(_mapTileFromX)) return;
+                _mapTileFromX = value;
+                OnPropertyChanged(nameof(MapTileFromX));
+            }
+        }
+
+        public int MapTileFromY
+        {
+            get { return _mapTileFromY; }
+            set
+            {
+                if (value.Equals(_mapTileFromY)) return;
+                _mapTileFromY = value;
+                OnPropertyChanged(nameof(MapTileFromY));
+            }
+        }
+
+        public bool MapTileToAny
+        {
+            get { return _mapTileToAny; }
+            set
+            {
+                if (value.Equals(_mapTileToAny)) return;
+                _mapTileToAny = value;
+                OnPropertyChanged(nameof(MapTileToAny));
+            }
+        }
+
+        public int MapTileToX
+        {
+            get { return _mapTileToX; }
+            set
+            {
+                if (value.Equals(_mapTileToX)) return;
+                _mapTileToX = value;
+                OnPropertyChanged(nameof(MapTileToX));
+            }
+        }
+
+        public int MapTileToY
+        {
+            get { return _mapTileToY; }
+            set
+            {
+                if (value.Equals(_mapTileToY)) return;
+                _mapTileToY = value;
+                OnPropertyChanged(nameof(MapTileToY));
             }
         }
 

--- a/rabi_splitter_WPF/SplitConditionSettings.xaml
+++ b/rabi_splitter_WPF/SplitConditionSettings.xaml
@@ -8,10 +8,11 @@
              d:DesignHeight="60" d:DesignWidth="300">
     <UserControl.Resources>
         <local:SplitTriggerToVisibilityConverter x:Key="SplitTriggerToVisibilityConverter"/>
+        <local:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
     </UserControl.Resources>
-    <StackPanel Name="MainPanel" Width="300" Height="60">
-        <TextBlock Text="{Binding Path=Label}"/>
-        <ComboBox ItemsSource="{Binding SplitConditionObject.SplitTriggerCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=SplitConditionObject.TriggerType, Mode=TwoWay}"/>
+    <StackPanel Name="MainPanel" Width="300">
+        <TextBlock Height="16" Text="{Binding Path=Label}"/>
+        <ComboBox Height="22" ItemsSource="{Binding SplitConditionObject.SplitTriggerCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=SplitConditionObject.TriggerType, Mode=TwoWay}"/>
         <Grid Visibility="{Binding SplitConditionObject.TriggerType, Converter={StaticResource SplitTriggerToVisibilityConverter}, ConverterParameter=MapChange, FallbackValue=Visible}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="3*" />
@@ -31,6 +32,43 @@
             <ComboBox Grid.Column="0" ItemsSource="{Binding SplitConditionObject.MusicCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=SplitConditionObject.MusicTypeFrom, Mode=TwoWay}"/>
             <TextBlock Grid.Column="1" Text=" &#x2794; " HorizontalAlignment="Center" VerticalAlignment="Center"/>
             <ComboBox Grid.Column="2" ItemsSource="{Binding SplitConditionObject.MusicCaptions}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding Path=SplitConditionObject.MusicTypeTo, Mode=TwoWay}"/>
+        </Grid>
+        <Grid Height="26" Visibility="{Binding SplitConditionObject.TriggerType, Converter={StaticResource SplitTriggerToVisibilityConverter}, ConverterParameter=MapTileChange, FallbackValue=Visible}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="0.45*" />
+                <ColumnDefinition Width="1.1*" />
+                <ColumnDefinition Width="0.3*" />
+                <ColumnDefinition Width="1.1*" />
+                <ColumnDefinition Width="0.6*" />
+                <ColumnDefinition Width="0.45*" />
+                <ColumnDefinition Width="1.1*" />
+                <ColumnDefinition Width="0.3*" />
+                <ColumnDefinition Width="1.1*" />
+            </Grid.ColumnDefinitions>
+            <Grid Grid.Column="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="4*"/>
+                    <RowDefinition Height="6*"/>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Text="Any" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <CheckBox Grid.Row="1" HorizontalAlignment="Center" IsChecked="{Binding SplitConditionObject.MapTileFromAny, Mode=TwoWay}"/>
+            </Grid>
+            <TextBox Grid.Column="1" Width="44" IsEnabled="{Binding SplitConditionObject.MapTileFromAny, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding SplitConditionObject.MapTileFromX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" FontSize="16" Padding="0,0"/>
+            <TextBlock Grid.Column="2" Text="," HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="3" Width="44" IsEnabled="{Binding SplitConditionObject.MapTileFromAny, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding SplitConditionObject.MapTileFromY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" FontSize="16" Padding="0,0"/>
+            <TextBlock Grid.Column="4" Text=" &#x2794; " HorizontalAlignment="Center" VerticalAlignment="Center"/>
+
+            <Grid Grid.Column="5">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="4*"/>
+                    <RowDefinition Height="6*"/>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Text="Any" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <CheckBox Grid.Row="1" HorizontalAlignment="Center" IsChecked="{Binding SplitConditionObject.MapTileToAny, Mode=TwoWay}"/>
+            </Grid>
+            <TextBox Grid.Column="6" Width="44" IsEnabled="{Binding SplitConditionObject.MapTileToAny, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding SplitConditionObject.MapTileToX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" FontSize="16" Padding="0,0"/>
+            <TextBlock Grid.Column="7" Text="," HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="8" Width="44" IsEnabled="{Binding SplitConditionObject.MapTileToAny, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding SplitConditionObject.MapTileToY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" FontSize="16" Padding="0,0"/>
         </Grid>
     </StackPanel>
 </UserControl>

--- a/rabi_splitter_WPF/StaticData.cs
+++ b/rabi_splitter_WPF/StaticData.cs
@@ -154,6 +154,8 @@ namespace rabi_splitter_WPF
         public static int[] EnemyPtrAddr = {0x00940EE0, 0x00964A1C, 0x0096BA3C, 0x0096DA3C, 0x012E1AF8, 0x012E2B08, 0x012E3B08 };
         public static int[] EnemyEntityHPOffset = {0x4c8, 0x4d0, 0x4d8, 0x4d8, 0x4d8, 0x4d8, 0x4d8 };
         public static int[] EnemyEntityIDOffset = {0x4e4, 0x4ec, 0x4F4, 0x4F4, 0x4F4, 0x4F4, 0x4F4 };
+        public static int[] EnemyEntityXPositionOffset = {0, 0, 0, 0xC, 0xC, 0xC, 0xC };
+        public static int[] EnemyEntityYPositionOffset = {0, 0, 0, 0x10, 0x10, 0x10, 0x10 };
         public static int[] EnemyEntitySize = {0x6F4, 0x6FC, 0x704, 0x704,0x704,0x704, 0x704 };
         public static int[] MoneyAddress = {0xD3823C, 0xD5B9FC, 0xD63D2C, 0xD654CC, 0x12D898C, 0x12D999C, 0x12DA99C };
         public static string[] VerNames = { "1.65", "1.70", "1.71", "1.75", "1.8","1.85","1.88"};


### PR DESCRIPTION
Summary of changes
- Port over map tile detection from rabiribi-display
- Add option to split on map tile in practice mode
- Port over optimized MemoryHelper class from rabiribi-display, so that the code reuses the process handle instead of opening a new one each memory address read. (also includes float support, which is needed for x/y coordinate reading)
- Display current music, current map and current maptile in the practice mode UI